### PR TITLE
fixup! Allow GoogleBattery HAL AIDL to run on pixel devices

### DIFF
--- a/googlebattery/turbo_adapter.te
+++ b/googlebattery/turbo_adapter.te
@@ -1,3 +1,3 @@
 # To find and bind Google Battery HAL
-allow turbo_adapter hal_googlebattery_hwservice:hwservice_manager find;
+allow turbo_adapter hal_googlebattery_service:service_manager find;
 binder_call(turbo_adapter, hal_googlebattery)


### PR DESCRIPTION
Bug was persistently throwing an avc denial and getting app crashes on screen. Upon research I found the derp when comparing the following:

https://github.com/AlphaDroid-Project/hardware_google_pixel-sepolicy/blob/alpha-13/googlebattery/turbo_adapter.te#L2

and

https://android.googlesource.com/platform/hardware/google/pixel-sepolicy/+/3334b5e659ad6058e657790dc52945e95e0b2ca3/googlebattery/turbo_adapter.te#2